### PR TITLE
Fixed permissions on module commands

### DIFF
--- a/modules/system/modules.py
+++ b/modules/system/modules.py
@@ -10,6 +10,7 @@ class Modules(commands.Cog):
         self.bot = bot
 
     @commands.group(name='module')
+    @commands.is_owner()
     async def module_group(self, ctx):
         if ctx.invoked_subcommand is None:
             await ctx.send('Invalid Module command.')


### PR DESCRIPTION
Module commands were originally accessible to any user.
This has now been limited to only the bot owner.